### PR TITLE
Dockerize Cinema Service API with README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.db
+*.sqlite3
+*.log
+*.env
+.env
+.git
+.gitignore
+.idea/
+.vscode/
+tests/
+*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,5 +10,4 @@ __pycache__/
 .gitignore
 .idea/
 .vscode/
-tests/
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10-slim
+
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,33 +1,45 @@
-# Dockerizing DRF Cinema
+# 🎬 Cinema Service API
 
-- Read [the guideline](https://github.com/mate-academy/py-task-guideline/blob/main/README.md) before start
-- Useful [link](https://saasitive.com/tutorial/django-celery-redis-postgres-docker-compose/) about theory 
-  (without Celery & redis of course)
+## Overview
+Cinema Service API is a Django REST Framework project for managing movies, cinema halls, sessions, and ticket bookings. It supports user registration, JWT authentication, and interactive API documentation.
 
-## Task:
+## Getting Started
+Clone the repo and run with Docker:
+```bash
+git clone https://github.com/your-username/py-dockerize-cinema.git
+cd py-dockerize-cinema
+docker-compose up --build
+```
 
-Here, you need to fully dockerize this existing DRF project Cinema. 
-You need to make your service fully independent of your local machine.
-So the only requirement to run your project is `Docker`.
+Create a superuser:
+```bash
+docker-compose run app python manage.py createsuperuser
+```
 
-### Task requirements:
-- Use `.dockerignore` for ignoring unnecessary stuff in your images;
-- Use `Dockerfile` for building `app` image with DRF application;
-- Use `docker-compose.yml` file for managing multiple services (containers) at the same time;
-- Switch to `PostgreSQL` database instead of `SQLite` using official docker image;
-- Implement `wait_for_db` 
-  [management command](https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/), 
-  which waits for the database to be available. 
-  So your services won't throw any errors during the `docker-compose up` command;
-- Make your docker images as thin as possible;
-- Use good practices of how to handle media, static files & volumes with docker.
+## API Docs
+Swagger UI → http://127.0.0.1:8000/api/docs/swagger-ui/
 
+Redoc → http://127.0.0.1:8000/api/docs/redoc/
 
-### How to check, that task is done:
-- Run `docker-compose up` command, and check with `docker ps`, that 2 services are up and running
-  (here check, that `app` is always waiting for `db` using `wait_for_db` command);
-- Go to `127.0.0.1:8000/api/` and check project endpoints via DRF interface (image uploading for sure);
-- Create new admin user. Enter container `docker exec -it <container_name> bash`, and create in from there;
-- Run tests using different approach: `docker-compose run app sh -c "python manage.py test"`;
-- If needed, also check the flake8: `docker-compose run app sh -c "flake8"`.
-- If everything is working fine - you are ready to push your code :).
+JSON Schema → http://127.0.0.1:8000/api/schema/
+
+## Authentication
+JWT endpoints:
+
+- POST /api/user/token/ → obtain token
+
+- POST /api/user/token/refresh/ → refresh token
+
+- POST /api/user/token/verify/ → verify token
+
+## Example Requests
+Register a user:
+```http
+POST /api/user/register/
+{
+  "email": "user@example.com",
+  "password": "strong_password",
+  "first_name": "John",
+  "last_name": "Doe"
+}
+

--- a/README.md
+++ b/README.md
@@ -42,4 +42,9 @@ POST /api/user/register/
   "first_name": "John",
   "last_name": "Doe"
 }
+```
+## Running Tests
 
+```bash
+docker-compose run app sh -c "python manage.py test"
+```

--- a/cinema/management/commands/wait_for_db.py
+++ b/cinema/management/commands/wait_for_db.py
@@ -9,8 +9,9 @@ class Command(BaseCommand):
         db_conn = None
         while not db_conn:
             try:
-                db_conn = connections['default']
-                db_conn.cursor()
+                connection = connections['default']
+                connection.cursor()
+                db_conn = connection
             except OperationalError:
                 self.stdout.write('Database unavailable, waiting 1 second...')
                 time.sleep(1)

--- a/cinema/management/commands/wait_for_db.py
+++ b/cinema/management/commands/wait_for_db.py
@@ -1,0 +1,17 @@
+import time
+from django.db import connections
+from django.db.utils import OperationalError
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        self.stdout.write('Waiting for database...')
+        db_conn = None
+        while not db_conn:
+            try:
+                db_conn = connections['default']
+                db_conn.cursor()
+            except OperationalError:
+                self.stdout.write('Database unavailable, waiting 1 second...')
+                time.sleep(1)
+        self.stdout.write(self.style.SUCCESS('Database available!'))

--- a/cinema/management/commands/wait_for_db.py
+++ b/cinema/management/commands/wait_for_db.py
@@ -3,16 +3,17 @@ from django.db import connections
 from django.db.utils import OperationalError
 from django.core.management.base import BaseCommand
 
+
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        self.stdout.write('Waiting for database...')
+        self.stdout.write("Waiting for database...")
         db_conn = None
         while not db_conn:
             try:
-                connection = connections['default']
+                connection = connections["default"]
                 connection.cursor()
                 db_conn = connection
             except OperationalError:
-                self.stdout.write('Database unavailable, waiting 1 second...')
+                self.stdout.write("Database unavailable, waiting 1 second...")
                 time.sleep(1)
-        self.stdout.write(self.style.SUCCESS('Database available!'))
+        self.stdout.write(self.style.SUCCESS("Database available!"))

--- a/cinema_service/settings.py
+++ b/cinema_service/settings.py
@@ -86,13 +86,13 @@ WSGI_APPLICATION = "cinema_service.wsgi.application"
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('DB_NAME', 'cinema'),
-        'USER': os.environ.get('DB_USER', 'cinema_user'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', 'cinema_pass'),
-        'HOST': os.environ.get('DB_HOST', 'localhost'),
-        'PORT': '5432',
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("DB_NAME", "cinema"),
+        "USER": os.environ.get("DB_USER", "cinema_user"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", "cinema_pass"),
+        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "PORT": "5432",
     }
 }
 

--- a/cinema_service/settings.py
+++ b/cinema_service/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 from datetime import timedelta
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -85,9 +86,13 @@ WSGI_APPLICATION = "cinema_service.wsgi.application"
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('DB_NAME', 'cinema'),
+        'USER': os.environ.get('DB_USER', 'cinema_user'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'cinema_pass'),
+        'HOST': os.environ.get('DB_HOST', 'localhost'),
+        'PORT': '5432',
     }
 }
 
@@ -132,6 +137,7 @@ USE_TZ = False
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "static"
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"

--- a/cinema_service/urls.py
+++ b/cinema_service/urls.py
@@ -1,23 +1,20 @@
-from django.conf import settings
-from django.conf.urls.static import static
-from django.contrib import admin
-from django.urls import path, include
+from django.urls import path
 from drf_spectacular.views import (
     SpectacularAPIView,
-    SpectacularSwaggerView,
     SpectacularRedocView,
+    SpectacularSwaggerView,
 )
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("api/cinema/", include("cinema.urls", namespace="cinema")),
-    path("api/user/", include("user.urls", namespace="user")),
-
-    # DRF Spectacular schema and docs
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("api/docs/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
-    path("api/docs/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
-
-    # Debug toolbar
-    path("__debug__/", include("debug_toolbar.urls")),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    path(
+        "api/docs/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/docs/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
+]

--- a/cinema_service/urls.py
+++ b/cinema_service/urls.py
@@ -12,16 +12,12 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/cinema/", include("cinema.urls", namespace="cinema")),
     path("api/user/", include("user.urls", namespace="user")),
+
+    # DRF Spectacular schema and docs
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path(
-        "api/doc/swagger/",
-        SpectacularSwaggerView.as_view(url_name="schema"),
-        name="swagger-ui",
-    ),
-    path(
-        "api/doc/redoc/",
-        SpectacularRedocView.as_view(url_name="schema"),
-        name="redoc",
-    ),
+    path("api/docs/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+    path("api/docs/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
+
+    # Debug toolbar
     path("__debug__/", include("debug_toolbar.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: cinema
+      POSTGRES_USER: cinema_user
+      POSTGRES_PASSWORD: cinema_pass
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  app:
+    build: .
+    command: >
+      sh -c "python manage.py wait_for_db &&
+             python manage.py migrate &&
+             python manage.py runserver 0.0.0.0:8000"
+    volumes:
+      - .:/app
+      - media:/app/media
+      - static:/app/static
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+      DB_NAME: cinema
+      DB_USER: cinema_user
+      DB_PASSWORD: cinema_pass
+      DB_HOST: db
+
+volumes:
+  postgres_data:
+  media:
+  static:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ djangorestframework
 djangorestframework-simplejwt
 drf-spectacular
 Pillow
+psycopg2-binary


### PR DESCRIPTION
## Summary
This PR introduces a Dockerized setup for the Cinema Service API and updates the README.md with clear instructions and example outputs.

## Changes
- Added Dockerfile and .dockerignore for reproducible, thin images
- Updated README.md with:
  - Step-by-step setup instructions
  - Example API requests and responses
  - Consistent image names and commands
- Created `develop` branch for ongoing improvements

## How to Test
1. Clone the repository
2. Build the Docker image:
   docker build -t cinema-service .
3. Run the container:
   docker run -p 8000:8000 cinema-service
4. Visit Swagger UI at:
   http://127.0.0.1:8000/api/docs/swagger-ui

## Notes
- SSH authentication configured for GitHub remote
- Ready for reviewer feedback
